### PR TITLE
Fix template and defaults bugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 ---
-jobs:
-  bake-ansible-images-v1:
-    uses: andrewrothstein/.github/.github/workflows/bake-ansible-images-v1.yml@develop
+name: build
 'on': push
+jobs:
+  dagger-ansible-test-role:
+    uses: andrewrothstein/docker-ansible/.github/workflows/dagger-ansible-test-role.yml@develop
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Dockerfile.*
 requirements.yml
 !meta/requirements.yml
 **/*undo-tree*
+.ansible

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,13 +9,13 @@ dnsmasq_configure_activate: true
 dnsmasq_configure_disable_systemd_resolved: false
 
 # defaults file for dnsmasq-configure
-#dnsmasq_configure_conf_dir: /etc
-#dnsmasq_configure_conf_filename: dnsmasq.conf
+# dnsmasq_configure_conf_dir: /etc
+# dnsmasq_configure_conf_filename: dnsmasq.conf
 
 # Listen on this specific port instead of the standard DNS port
 # (53). Setting this to zero completely disables DNS function,
 # leaving only DHCP and/or TFTP.
-#dnsmasq_configure_port: 5353
+# dnsmasq_configure_port: 5353
 
 # The following two options make you a better netizen, since they
 # tell dnsmasq to filter out queries which the public DNS cannot
@@ -24,13 +24,13 @@ dnsmasq_configure_disable_systemd_resolved: false
 # these requests from bringing up the link unnecessarily.
 
 # Never forward plain names (without a dot or domain part)
-#dnsmasq_configure_domain_needed: true
+# dnsmasq_configure_domain_needed: true
 # Never forward addresses in the non-routed address spaces.
-#dnsmasq_configure_bogus_priv: true
+# dnsmasq_configure_bogus_priv: true
 # Uncomment these to enable DNSSEC validation and caching:
 # (Requires dnsmasq to be built with DNSSEC option.)
-#dnsmasq_configure_conf_file: /usr/share/dnsmasq/trust-anchors.conf
-#dnsmasq_configure_dnssec: true
+# dnsmasq_configure_conf_file: /usr/share/dnsmasq/trust-anchors.conf
+# dnsmasq_configure_dnssec: true
 
 # Replies which are not DNSSEC signed may be legitimate, because the domain
 # is unsigned, or may be forgeries. Setting this option tells dnsmasq to
@@ -38,51 +38,51 @@ dnsmasq_configure_disable_systemd_resolved: false
 # record somewhere between the root and the domain does not exist.
 # The cost of setting this is that even queries in unsigned domains will need
 # one or more extra DNS queries to verify.
-#dnsmasq_configure_dnssec_check_unsigned: true
+# dnsmasq_configure_dnssec_check_unsigned: true
 # Uncomment this to filter useless windows-originated DNS requests
 # which can trigger dial-on-demand links needlessly.
 # Note that (amongst other things) this blocks all SRV requests,
 # so don't use it if you use eg Kerberos, SIP, XMMP or Google-talk.
 # This option only affects forwarding, SRV records originating for
 # dnsmasq (via srv-host= lines) are not suppressed by it.
-#dnsmasq_configure_filterwin2k: true
+# dnsmasq_configure_filterwin2k: true
 
 # Change this line if you want dns to get its upstream servers from
 # somewhere other that /etc/resolv.conf
-#dnsmasq_configure_resolv_file=/etc/foo/resolv.conf
+# dnsmasq_configure_resolv_file=/etc/foo/resolv.conf
 
 # By  default,  dnsmasq  will  send queries to any of the upstream
 # servers it knows about and tries to favour servers to are  known
 # to  be  up.  Uncommenting this forces dnsmasq to try each query
 # with  each  server  strictly  in  the  order  they   appear   in
 # /etc/resolv.conf
-#dnsmasq_configure_strict_order: true
+# dnsmasq_configure_strict_order: true
 
 # If you don't want dnsmasq to read /etc/resolv.conf or any other
 # file, getting its servers from this file instead (see below), then
 # uncomment this.
-#dnsmasq_configure_no_resolv: true
+# dnsmasq_configure_no_resolv: true
 # If you don't want dnsmasq to poll /etc/resolv.conf or other resolv
 # files for changes and re-read them then uncomment this.
-#dnsmasq_configure_no_poll: true
+# dnsmasq_configure_no_poll: true
 
 # Add other name servers here, with domain specs if they are for
 # non-public domains.
-#dnsmasq_configure_servers:
+# dnsmasq_configure_servers:
 #  - domain: localnet
 #    ip: 192.168.0.1
 # Example of routing PTR queries to nameservers: this will send all
 # address->name queries for 192.168.3/24 to nameserver 10.1.2.3
-#dnsmasq_configure_servers:
+# dnsmasq_configure_servers:
 #  - domain: '3.168.192.in-addr.arpa'
 #    ip: 10.1.2.3
 
 # configure reverse servers
-#dnsmasq_configure_rev_servers:
+# dnsmasq_configure_rev_servers:
 #  subnet: 10.0.0.0/8
 #  nameserver: 127.0.0.1#8600
 
-#dnsmasq_configure_rev_servers:
+# dnsmasq_configure_rev_servers:
 #  subnets:
 #    - 0.0.0.0/8
 #    - 10.0.0.0/8
@@ -90,24 +90,24 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Add local-only domains here, queries in these domains are answered
 # from /etc/hosts or DHCP only.
-#dnsmasq_configure_locals:
+# dnsmasq_configure_locals:
 #  - localnet
 
 # Add domains which you want to force to an IP address here.
 # The example below send any host in double-click.net to a local
 # web-server.
-#dnsmasq_configure_addresses:
+# dnsmasq_configure_addresses:
 #  - domain: double-click.net
 #    ip: '127.0.0.1'
 
 # --address (and --server) work with IPv6 addresses too.
-#dnsmasq_configure_addresses:
+# dnsmasq_configure_addresses:
 #  - domain: www.thekelleys.org.uk
 #    ip: 'fe80::20d:60ff:fe36:f83'
 
 # Add the IPs of all queries to yahoo.com, google.com, and their
 # subdomains to the vpn and search ipsets:
-#dnsmasq_configure_ipsets:
+# dnsmasq_configure_ipsets:
 #  - domains:
 #      - yahoo.com
 #      - google.com
@@ -117,43 +117,43 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # You can control how dnsmasq talks to a server: this forces
 # queries to 10.1.2.3 to be routed via eth1
-#dnsmasq_configure_talks:
+# dnsmasq_configure_talks:
 #  - server: '10.1.2.3'
 #    target: eth1
 
 # and this sets the source (ie local) address used to talk to
 # 10.1.2.3 to 192.168.1.1 port 55 (there must be a interface with that
 # IP on the machine, obviously).
-#dnsmasq_configure_talks:
+# dnsmasq_configure_talks:
 #  - server: '10.1.2.3'
 #    target: 192.168.1.1
 #    port: 55
 
 # If you want dnsmasq to change uid and gid to something other
 # than the default, edit the following lines.
-#dnsmasq_configure_user: root
-#dnsmasq_configure_group: root
+# dnsmasq_configure_user: root
+# dnsmasq_configure_group: root
 
 # If you want dnsmasq to listen for DHCP and DNS requests only on
 # specified interfaces (and the loopback) give the name of the
 # interface (eg eth0) here.
 # Repeat the line for more than one interface.
-#dnsmasq_configure_interfaces:
+# dnsmasq_configure_interfaces:
 #  - enp1s0
 
 # Or you can specify which interface _not_ to listen on
-#dnsmasq_configure_except_interfaces:
+# dnsmasq_configure_except_interfaces:
 #  - wlp3s0
 
 # Or which to listen on by address (remember to include 127.0.0.1 if
 # you use this.)
-#dnsmasq_configure_listen_addresses:
+# dnsmasq_configure_listen_addresses:
 #  - '172.16.0.1'
 #  - '127.0.0.1'
 # If you want dnsmasq to provide only DNS service on an interface,
 # configure it as shown above, and then use the following line to
 # disable DHCP and TFTP on it.
-#dnsmasq_configure_no_dhcp_interfaces:
+# dnsmasq_configure_no_dhcp_interfaces:
 #  - wlp3s0
 
 # On systems which support it, dnsmasq binds the wildcard address,
@@ -163,19 +163,19 @@ dnsmasq_configure_disable_systemd_resolved: false
 # want dnsmasq to really bind only the interfaces it is listening on,
 # uncomment this option. About the only time you may need this is when
 # running another nameserver on the same machine.
-#dnsmasq_configure_bind_interfaces: true
+# dnsmasq_configure_bind_interfaces: true
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.
-#dnsmasq_configure_no_hosts: true
+# dnsmasq_configure_no_hosts: true
 # or if you want it to read another file, as well as /etc/hosts, use
 # this.
-#dnsmasq_configure_addn_hosts:
+# dnsmasq_configure_addn_hosts:
 #  - /etc/banner_add_hosts
 
 # Set this (and domain: see below) if you want to have a domain
 # automatically added to simple names in a hosts-file.
-#dnsmasq_configure_expand_hosts: true
+# dnsmasq_configure_expand_hosts: true
 
 # Set the domain for dnsmasq. this is optional, but if it is set, it
 # does the following things.
@@ -184,16 +184,16 @@ dnsmasq_configure_disable_systemd_resolved: false
 # 2) Sets the "domain" DHCP option thereby potentially setting the
 #    domain of all systems configured by DHCP
 # 3) Provides the domain part for "expand-hosts"
-#dnsmasq_configure_domains:
+# dnsmasq_configure_domains:
 #  - domain: drewfus.org
 
 # Set a different domain for a particular subnet
-#dnsmasq_configure_domains:
+# dnsmasq_configure_domains:
 #  - domain: wireless.thekelleys.org.uk
 #    subnet: '192.168.2.0/24'
 
 # Same idea, but range rather then subnet
-#dnsmasq_configure_domains:
+# dnsmasq_configure_domains:
 #  - domain: drewfus.org
 #    range:
 #      from: '192.168.3.2'
@@ -204,7 +204,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # a lease time. If you have more than one network, you will need to
 # repeat this for each network on which you want to supply DHCP
 # service.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - range:
 #      from: '172.16.1.1'
 #      to: '172.31.255.255'
@@ -213,7 +213,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # is needed for networks we reach the dnsmasq DHCP server via a relay
 # agent. If you don't know what a DHCP relay agent is, you probably
 # don't need to worry about this.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - range:
 #      from: '192.168.3.2'
 #      to: '192.168.3.255'
@@ -222,13 +222,13 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # This is an example of a DHCP range which sets a tag, so that
 # some DHCP options may be set only for this network.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - set: red
 #    range:
 #      from: '192.168.0.50'
 #      to: '192.168.0.150'
 # Use this DHCP range only when the tag "green" is set.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - set: green
 #    range:
 #      from: '192.168.0.50'
@@ -242,12 +242,12 @@ dnsmasq_configure_disable_systemd_resolved: false
 # In this case the netmask is implied (it comes from the network
 # configuration on the machine running dnsmasq) it is possible to give
 # an explicit netmask instead.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - static: '192.168.0.0'
 
 # Enable DHCPv6. Note that the prefix-length does not need to be specified
 # and defaults to 64 if missing/
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - range:
 #      from: '1234::2'
 #      to: '1234::500'
@@ -255,7 +255,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 #    duration: '12h'
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
 #    ra_only: true
 
@@ -264,20 +264,20 @@ dnsmasq_configure_disable_systemd_resolved: false
 # hosts. Use the DHCPv4 lease to derive the name, network segment and 
 # MAC address and assume that the host will also have an
 # IPv6 address calculated using the SLAAC alogrithm.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
 #    ra_names: true
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet.
 # Set the lifetime to 46 hours. (Note: minimum lifetime is 2 hours.)
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - subnet:  '1234::'
 #    ra_only: true
 #    duration: '48h'
 
 # Do DHCP and Router Advertisements for this subnet. Set the A bit in the RA
 # so that clients can use SLAAC addresses as well as DHCP ones.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - range:
 #      from: '1234::2'
 #      to: '1234::500'
@@ -286,14 +286,14 @@ dnsmasq_configure_disable_systemd_resolved: false
 # Do Router Advertisements and stateless DHCP for this subnet. Clients will
 # not get addresses from DHCP, but they will get other configuration information.
 # They will use SLAAC for addresses.
-#dnsmasq_configure_dhcp_ranges:
+# dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
 #    ra_stateless: true
 
 # Do stateless DHCP, SLAAC, and generate DNS names for SLAAC addresses
 # from DHCPv4 leases.
-#dhcp-range=1234::, ra-stateless, ra-names
-#dnsmasq_configure_dhcp_ranges:
+# dhcp-range=1234::, ra-stateless, ra-names
+# dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
 #    ra_stateless: true
 #    ra_names: true
@@ -303,7 +303,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # advertisements will have the M and O bits set, so that the clients
 # get addresses and configuration from DHCPv6, and the A bit reset, so the 
 # clients don't use SLAAC addresses.
-#dnsmasq_configure_enable_ra: true
+# dnsmasq_configure_enable_ra: true
 
 # Supply parameters for specified hosts using DHCP. There are lots
 # of valid alternatives, so we will give examples of each. Note that
@@ -314,19 +314,19 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Always allocate the host with Ethernet address 11:22:33:44:55:66
 # The IP address 192.168.0.60
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
 #    address: '192.168.0.60'
 
 # Always set the name of the host with hardware address
 # 11:22:33:44:55:66 to be "fred"
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
 #    host: fred
 
 # Always give the host with Ethernet address 11:22:33:44:55:66
 # the name fred and IP address 192.168.0.60 and lease time 45 minutes
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
 #    host: fred
 #    address: '192.168.0.60'
@@ -334,14 +334,14 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Give the machine which says its name is "bert" IP address
 # 192.168.0.70 and an infinite lease
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: bert
 #    address: '192.168.0.70'
 #    infinite: true
 
 # Always give the host with client identifier 01:02:02:04
 # the IP address 192.168.0.60
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: id:01:02:02:04
 #    address: '192.168.0.60'
 
@@ -350,25 +350,25 @@ dnsmasq_configure_disable_systemd_resolved: false
 # ip address 192.168.0.61. The client id is derived from the prefix
 # ff:00:00:00:00:00:02:00:00:02:c9:00 and the last 8 pairs of
 # hex digits of the hardware address.
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: id:ff:00:00:00:00:00:02:00:00:02:c9:00:f4:52:14:03:00:28:05:81
 #    address: '192.168.0.61'
 
 # Always give the host with client identifier "marjorie"
 # the IP address 192.168.0.60
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: id:marjorie
 #    address: '192.168.0.60'
 
 # Enable the address given for "judge" in /etc/hosts
 # to be given to a machine presenting the name "judge" when
 # it asks for a DHCP lease.
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: judge
 
 # Never offer DHCP service to a machine whose Ethernet
 # address is 11:22:33:44:55:66
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
 #    ignore: true
 
@@ -376,19 +376,19 @@ dnsmasq_configure_disable_systemd_resolved: false
 # address 11:22:33:44:55:66. This is useful to prevent a machine
 # being treated differently when running under different OS's or
 # between PXE boot and OS boot.
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
 #    ignore_all: true
 
 # Send extra options which are tagged as "red" to
 # the machine with Ethernet address 11:22:33:44:55:66
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
 #    set: red
 
 # Send extra options which are tagged as "red" to
 # any machine with Ethernet address starting 11:22:33:
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:*:*:*'
 #    set: red
 
@@ -396,7 +396,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # DUID 00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2
 # Note the MAC addresses CANNOT be used to identify DHCPv6 clients.
 # Note also the they [] around the IPv6 address are obilgatory.
-#dnsmasq_configure_dhcp_hosts:
+# dnsmasq_configure_dhcp_hosts:
 #  - mac: id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2
 #    host: fred
 #    ipv6: '1234::5'
@@ -405,23 +405,23 @@ dnsmasq_configure_disable_systemd_resolved: false
 # or /etc/ethers. Equivalent to ISC "deny unknown-clients".
 # This relies on the special "known" tag which is set when
 # a host is matched.
-#dnsmasq_configure_dhcp_ignore_tag: !known
+# dnsmasq_configure_dhcp_ignore_tag: !known
 
 # Send extra options which are tagged as "red" to any machine whose
 # DHCP vendorclass string includes the substring "Linux"
-#dnsmasq_configure_dhcp_vendor_classes:
+# dnsmasq_configure_dhcp_vendor_classes:
 #  - set: red
 #    includes: Linux
 
 # Send extra options which are tagged as "red" to any machine one
 # of whose DHCP userclass strings includes the substring "accounts"
-#dnsmasq_configure_dhcp_user_classes:
+# dnsmasq_configure_dhcp_user_classes:
 #  - set: red
 #    includes: accounts
 
 # Send extra options which are tagged as "red" to any machine whose
 # MAC address matches the pattern.
-#dnsmasq_configure_dhcp_macs:
+# dnsmasq_configure_dhcp_macs:
 #  - set: red
 #    mac_pattern: '00:60:8C:*:*:*'
 
@@ -429,7 +429,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # on the ethernet-address/IP pairs found there just as if they had
 # been given as --dhcp-host options. Useful if you keep
 # MAC-address/host mappings there for other purposes.
-#dnsmasq_configure_read_ethers: true
+# dnsmasq_configure_read_ethers: true
 
 # Send options to hosts which ask for a DHCP lease.
 # See RFC 2132 for details of available options.
@@ -444,12 +444,12 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Override the default route supplied by dnsmasq, which assumes the
 # router is the same machine as the one running dnsmasq.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 3
 #    val: '1.2.3.4'
 
 # Do the same thing, but using the option name
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option:router
 #    val: '1.2.3.4'
 
@@ -457,18 +457,18 @@ dnsmasq_configure_disable_systemd_resolved: false
 # route at all. Note that this only works for the options sent by
 # default (1, 3, 6, 12, 28) the same line will send a zero-length option
 # for all other option numbers.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 3
 
 # Set the NTP time server addresses to 192.168.0.4 and 10.10.0.5
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option:ntp-server
 #    vals:
 #      - '192.168.0.4'
 #      - '10.10.0.5'
 
 # Send DHCPv6 option. Note [] around IPv6 addresses.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option6:dns-server
 #    vals:
 #      - '[1234::77]'
@@ -476,52 +476,52 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Send DHCPv6 option for namservers as the machine running
 # dnsmasq and another.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option6:dns-server
 #    vals:
 #      - '[::]'
 #      - '[1234::88]'
 
 # Ask client to poll for option changes every six hours. (RFC4242)
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option6:information-refresh-time
 #    val: '6h'
 
 # Set option 58 client renewal time (T1). Defaults to half of the
 # lease time if not specified. (RFC2132)
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option:T1
 #    val: '1m'
 
 # Set option 59 rebinding time (T2). Defaults to 7/8 of the
 # lease time if not specified. (RFC2132)
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option:T2
 #    val: '2m'
 
 # Set the NTP time server address to be the same machine as
 # is running dnsmasq
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 42
 #    val: '0.0.0.0'
 
 # Set the NIS domain name to "welly"
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 40
 #    val: welly
 
 # Set the default time-to-live to 50
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 23
 #    val: 50
 
 # Set the "all subnets are local" flag
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 27
 #    val: 1
 
 # Send the etherboot magic flag and then etherboot options (a string).
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 128
 #    val: e4:45:74:68:00:00
 #  - opt: 129
@@ -530,7 +530,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # Specify an option which will only be sent to the "red" network
 # (see dhcp-range for the declaration of the "red" network)
 # Note that the tag: part must precede the option: part.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - tag: red
 #    opt: option:ntp-server
 #    val: '192.168.1.1'
@@ -542,7 +542,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # dnsmasq is also the host running samba.
 # you may want to uncomment some or all of them if you use
 # Windows clients and Samba.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 19
 #    val: 0
 #  - opt: 44
@@ -555,20 +555,20 @@ dnsmasq_configure_disable_systemd_resolved: false
 #    val: 8
 
 # Send an empty WPAD option. This may be REQUIRED to get windows 7 to behave.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 252
 #    val: '"\n"'
 
 # Send RFC-3397 DNS domain search DHCP option. WARNING: Your DHCP client
 # probably doesn't support this......
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: option:domain-search
 #    vals:
 #      - eng.apple.com
 #      - marketing.apple.com
 
 # Send RFC-3442 classless static routes (note the netmask encoding)
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: 121
 #    vals:
 #      - '192.168.1.0/24'
@@ -582,7 +582,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # matches the class given here. (A substring match is OK, so "MSFT"
 # matches "MSFT" and "MSFT 5.0"). This example sets the
 # mtftp address to 0.0.0.0 for PXEClients.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: vendor:PXEClient
 #    vals:
 #      - 1
@@ -592,7 +592,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 # when it shuts down. Note the "i" flag, to tell dnsmasq to send the
 # value as a four-byte integer - that's what microsoft wants. See
 # http://technet2.microsoft.com/WindowsServer/en/library/a70f1bb7-d2d4-49f0-96d6-4b7414ecfaae1033.mspx?mfr=true
-#dnmasq_configure_dhcp_options:
+# dnmasq_configure_dhcp_options:
 #  - opt: vendor:MSFT
 #    vals:
 #      - 2
@@ -600,7 +600,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Send the Encapsulated-vendor-class ID needed by some configurations of
 # Etherboot to allow is to recognise the DHCP server.
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: vendor:Etherboot
 #    vals:
 #      - 60
@@ -611,25 +611,25 @@ dnsmasq_configure_disable_systemd_resolved: false
 # to use dhcp-option-force here.
 # See http://syslinux.zytor.com/pxe.php#special for details.
 # Magic number - needed before anything else is recognised
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - force: true
 #    opt: 208
 #    val: f1:00:74:7e
 
 # Configuration file name
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - force: true
 #    opt: 209
 #    val: configs/common
 
 # Path prefix
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - force: true
 #    opt: 10
 #    val: /tftpboot/pxelinux/files/
 
 # Reboot time. (Note 'i' to send 32-bit value)
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - force: true
 #    opt: 211
 #    val: '30i'
@@ -638,11 +638,11 @@ dnsmasq_configure_disable_systemd_resolved: false
 # this is you want to boot machines over the network and you will need
 # a TFTP server; either dnsmasq's built in TFTP server or an
 # external one. (See below for how to enable the TFTP server.)
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - file: pxelinux.0
 
 # The same as above, but use custom tftp-server instead machine running dnsmasq
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - file: pxelinux
 #    host: server.name
 #    address: 192.168.1.100
@@ -651,43 +651,43 @@ dnsmasq_configure_disable_systemd_resolved: false
 # filenames, the first loads gPXE, and the second tells gPXE what to
 # load. The dhcp-match sets the gpxe tag for requests from gPXE.
 # gPXE sends a 175 option.
-#dnsmasq_configure_dhcp_matches:
+# dnsmasq_configure_dhcp_matches:
 #  - set: gpxe
 #    val: 175
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - tag: !gpxe
 #    file: undionly.kpxe
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - file: mybootimage
 
 # Encapsulated options for Etherboot gPXE. All the options are
 # encapsulated within option 175
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: encap:175 # priority code
 #    vals:
 #      - 1
 #      - '5b'
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: encap:175 # no-proxydhcp
 #    vals:
 #      - 176
 #      - '1b'
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: encap:175 # bus-id
 #    vals:
 #      - 177
 #      - string
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: encap:175 # BIOS drive code
 #    vals:
 #      - 189
 #      - '1b'
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: encap:175 # iSCSI username
 #    vals:
 #      - 190
 #      - user
-#dnsmasq_configure_dhcp_options:
+# dnsmasq_configure_dhcp_options:
 #  - opt: encap:175 # iSCSI password
 #    vals:
 #      - 191
@@ -695,7 +695,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Test for the architecture of a netboot client. PXE clients are
 # supposed to send their architecture as option 93. (See RFC 4578)
-#dnsmasq_configure_dhcp_matches:
+# dnsmasq_configure_dhcp_matches:
 #  - opt: peecees, option:client-arch
 #    val: 0 #x86-32
 #  - opt: itanics, option:client-arch
@@ -707,72 +707,72 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Do real PXE, rather than just booting a single file, this is an
 # alternative to dhcp-boot.
-#dnsmasq_configure_pxe_prompts:
+# dnsmasq_configure_pxe_prompts:
 #  - prompt: What system shall I netboot?
 # or with timeout before first available action is taken:
-#dnsmasq_configure_pxe_prompts:
+# dnsmasq_configure_pxe_prompts:
 #  - prompt: Press F8 for menu.
 #    wait: 60
 
 # Available boot services. for PXE.
-#dnsmasq_configure_pxe_services:
+# dnsmasq_configure_pxe_services:
 #  - id: x86PC
 #    name: Boot from local disk
 
 # Loads <tftp-root>/pxelinux.0 from dnsmasq TFTP server.
-#dnsmasq_configure_pxe_services:
+# dnsmasq_configure_pxe_services:
 #  - id: x86PC
 #    name: Install Linux
 #    image: pxelinux
 
 # Loads <tftp-root>/pxelinux.0 from TFTP server at 1.2.3.4.
 # Beware this fails on old PXE ROMS.
-#dnsmasq_configure_pxe_services:
+# dnsmasq_configure_pxe_services:
 #  - id: x86PC
 #    name: Install Linux
 #    image: pxelinux
 #    tftp_server: '1.2.3.4'
 
 # Use bootserver on network, found my multicast or broadcast.
-#dnsmasq_configure_pxe_services:
+# dnsmasq_configure_pxe_services:
 #  - id: x86PC
 #    name: Install windows from RIS server
 #    image: 1
 
 # Use bootserver at a known IP address.
-#dnsmasq_configure_pxe_services:
+# dnsmasq_configure_pxe_services:
 #  - id: x86PC
 #    name: Install windows from RIS server
 #    image: 1
 #    tftp_server: 1.2.3.4
 
 # Enable dnsmasq's built-in TFTP server
-#dnsmasq_configure_enable_tftp: true
+# dnsmasq_configure_enable_tftp: true
 
 # Set the root directory for files available via FTP.
-#dnsmasq_configure_tftp_root: /var/lib/tftpboot
+# dnsmasq_configure_tftp_root: /var/lib/tftpboot
 
 # Do not abort if the tftp-root is unavailable
-#dnsmasq_configure_tftp_no_fail: true
+# dnsmasq_configure_tftp_no_fail: true
 
 # Make the TFTP server more secure: with this set, only files owned by
 # the user dnsmasq is running as will be send over the net.
-#dnsmasq_configure_tftp_secure: true
+# dnsmasq_configure_tftp_secure: true
 
 # This option stops dnsmasq from negotiating a larger blocksize for TFTP
 # transfers. It will slow things down, but may rescue some broken TFTP
 # clients.
-#dnsmasq_configure_tftp_no_blocksize: true
+# dnsmasq_configure_tftp_no_blocksize: true
 
 # Set the boot file name only when the "red" tag is set.
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - tag: red
 #    file: pxelinux.red-net
 
 # An example of dhcp-boot with an external TFTP server: the name and IP
 # address of the server are given after the filename.
 # Can fail with old PXE ROMS. Overridden by --pxe-service.
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - file: /var/ftpd/pxelinux.0
 #    tftp_serverhosts:
 #      - boothost
@@ -784,19 +784,19 @@ dnsmasq_configure_disable_systemd_resolved: false
 # case dnsmasq resolves this name and returns the resultant IP
 # addresses in round robin fasion. This facility can be used to
 # load balance the tftp load among a set of servers.
-#dnsmasq_configure_dhcp_boots:
+# dnsmasq_configure_dhcp_boots:
 #  - file: /var/ftpd/pxelinux.0
 #    tftp_serverhosts:
 #      - boothost
 #      - tftp_server_name
 
 # Set the limit on DHCP leases, the default is 150
-#dnsmasq_configure_dhcp_lease_max: 150
+# dnsmasq_configure_dhcp_lease_max: 150
 
 # The DHCP server needs somewhere on disk to keep its lease database.
 # This defaults to a sane location, but if you want to change it, use
 # the line below.
-#dnsmasq_configure_dhcp_leasefile: /var/lib/dnsmasq/dnsmasq.leases
+# dnsmasq_configure_dhcp_leasefile: /var/lib/dnsmasq/dnsmasq.leases
 
 # Set the DHCP server to authoritative mode. In this mode it will barge in
 # and take over the lease for any client which broadcasts on the network,
@@ -806,49 +806,49 @@ dnsmasq_configure_disable_systemd_resolved: false
 # server for your campus/company accidentally. The ISC server uses
 # the same option, and this URL provides more information:
 # http://www.isc.org/files/auth.html
-#dnsmasq_configure_dhcp_authoritative: true
+# dnsmasq_configure_dhcp_authoritative: true
 
 # Run an executable when a DHCP lease is created or destroyed.
 # The arguments sent to the script are "add" or "del",
 # then the MAC address, the IP address and finally the hostname
 # if there is one.
-#dnsmasq_configure_dhcp_script: /bin/echo
+# dnsmasq_configure_dhcp_script: /bin/echo
 
 # Set the cachesize here.
-#dnsmasq_configure_cache_size: 150
+# dnsmasq_configure_cache_size: 150
 
 # If you want to disable negative caching, uncomment this.
-#dnsmasq_configure_no_negcache: true
+# dnsmasq_configure_no_negcache: true
 
 # Normally responses which come from /etc/hosts and the DHCP lease
 # file have Time-To-Live set as zero, which conventionally means
 # do not cache further. If you are happy to trade lower load on the
 # server for potentially stale date, you can set a time-to-live (in
 # seconds) here.
-#dnsmasq_configure_local_ttl: 30
+# dnsmasq_configure_local_ttl: 30
 
 # If you want dnsmasq to detect attempts by Verisign to send queries
 # to unregistered .com and .net hosts to its sitefinder service and
 # have dnsmasq instead return the correct NXDOMAIN response, uncomment
 # this line. You can add similar lines to do the same for other
 # registries which have implemented wildcard A records.
-#dnsmasq_configure_bogus_nxdomain: '64.94.110.11'
+# dnsmasq_configure_bogus_nxdomain: '64.94.110.11'
 
 # If you want to fix up DNS results from upstream servers, use the
 # alias option. This only works for IPv4.
 # This alias makes a result of 1.2.3.4 appear as 5.6.7.8
-#dnsmasq_configure_aliases:
+# dnsmasq_configure_aliases:
 #  - src: '1.2.3.4'
 #    dest: '5.6.7.8'
 
 # and this maps 1.2.3.x to 5.6.7.x
-#dnsmasq_configure_aliases:
+# dnsmasq_configure_aliases:
 #  - src: '1.2.3.0'
 #    dest: '5.6.7.0'
 #    netmask: '255.255.255.0'
 
 # and this maps 192.168.0.10->192.168.0.40 to 10.0.0.10->10.0.0.40
-#dnsmasq_configure_aliases:
+# dnsmasq_configure_aliases:
 #  - src: '192.168.0.10-192.168.0.40'
 #    dest: '10.0.0.0'
 #    netmask: '255.255.255.0'
@@ -857,13 +857,13 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Return an MX record named "maildomain.com" with target
 # servermachine.com and preference 50
-#dnsmasq_configure_mx_host:
+# dnsmasq_configure_mx_host:
 #  record: maildomain.com
 #  target: servermachine.com
 #  preference: 50
 
 # Set the default target for MX records created using the localmx option.
-#dnsmasq_configure_mx_target: servermachine.com
+# dnsmasq_configure_mx_target: servermachine.com
 
 # Return an MX record pointing to the mx-target for all local
 # machines.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -260,8 +260,8 @@ dnsmasq_configure_disable_systemd_resolved: false
 #    ra_only: true
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet, also try and
-# add names to the DNS for the IPv6 address of SLAAC-configured dual-stack 
-# hosts. Use the DHCPv4 lease to derive the name, network segment and 
+# add names to the DNS for the IPv6 address of SLAAC-configured dual-stack
+# hosts. Use the DHCPv4 lease to derive the name, network segment and
 # MAC address and assume that the host will also have an
 # IPv6 address calculated using the SLAAC alogrithm.
 # dnsmasq_configure_dhcp_ranges:
@@ -299,9 +299,9 @@ dnsmasq_configure_disable_systemd_resolved: false
 #    ra_names: true
 
 # Do router advertisements for all subnets where we're doing DHCPv6
-# Unless overriden by ra-stateless, ra-names, et al, the router 
+# Unless overriden by ra-stateless, ra-names, et al, the router
 # advertisements will have the M and O bits set, so that the clients
-# get addresses and configuration from DHCPv6, and the A bit reset, so the 
+# get addresses and configuration from DHCPv6, and the A bit reset, so the
 # clients don't use SLAAC addresses.
 # dnsmasq_configure_enable_ra: true
 
@@ -392,7 +392,7 @@ dnsmasq_configure_disable_systemd_resolved: false
 #  - mac: '11:22:33:*:*:*'
 #    set: red
 
-# Give a fixed IPv6 address and name to client with 
+# Give a fixed IPv6 address and name to client with
 # DUID 00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2
 # Note the MAC addresses CANNOT be used to identify DHCPv6 clients.
 # Note also the they [] around the IPv6 address are obilgatory.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
-dnsmasq_configure_privilege_escalate: True
+dnsmasq_configure_privilege_escalate: true
 
 # to activate or not the dnsmasq service
-dnsmasq_configure_activate: True
+dnsmasq_configure_activate: true
 
 # disable the systemd-resolved service when activating dnsmasq
 # to prevent them from crashing into each other
-dnsmasq_configure_disable_systemd_resolved: False
+dnsmasq_configure_disable_systemd_resolved: false
 
 # defaults file for dnsmasq-configure
 #dnsmasq_configure_conf_dir: /etc
@@ -24,28 +24,28 @@ dnsmasq_configure_disable_systemd_resolved: False
 # these requests from bringing up the link unnecessarily.
 
 # Never forward plain names (without a dot or domain part)
-#dnsmasq_configure_domain_needed: True
+#dnsmasq_configure_domain_needed: true
 # Never forward addresses in the non-routed address spaces.
-#dnsmasq_configure_bogus_priv: True
+#dnsmasq_configure_bogus_priv: true
 # Uncomment these to enable DNSSEC validation and caching:
 # (Requires dnsmasq to be built with DNSSEC option.)
 #dnsmasq_configure_conf_file: /usr/share/dnsmasq/trust-anchors.conf
-#dnsmasq_configure_dnssec: True
+#dnsmasq_configure_dnssec: true
 
 # Replies which are not DNSSEC signed may be legitimate, because the domain
 # is unsigned, or may be forgeries. Setting this option tells dnsmasq to
-# check that an unsigned reply is OK, by finding a secure proof that a DS 
-# record somewhere between the root and the domain does not exist. 
+# check that an unsigned reply is OK, by finding a secure proof that a DS
+# record somewhere between the root and the domain does not exist.
 # The cost of setting this is that even queries in unsigned domains will need
 # one or more extra DNS queries to verify.
-#dnsmasq_configure_dnssec_check_unsigned: True
+#dnsmasq_configure_dnssec_check_unsigned: true
 # Uncomment this to filter useless windows-originated DNS requests
 # which can trigger dial-on-demand links needlessly.
 # Note that (amongst other things) this blocks all SRV requests,
 # so don't use it if you use eg Kerberos, SIP, XMMP or Google-talk.
 # This option only affects forwarding, SRV records originating for
 # dnsmasq (via srv-host= lines) are not suppressed by it.
-#dnsmasq_configure_filterwin2k: True
+#dnsmasq_configure_filterwin2k: true
 
 # Change this line if you want dns to get its upstream servers from
 # somewhere other that /etc/resolv.conf
@@ -56,15 +56,15 @@ dnsmasq_configure_disable_systemd_resolved: False
 # to  be  up.  Uncommenting this forces dnsmasq to try each query
 # with  each  server  strictly  in  the  order  they   appear   in
 # /etc/resolv.conf
-#dnsmasq_configure_strict_order: True
+#dnsmasq_configure_strict_order: true
 
 # If you don't want dnsmasq to read /etc/resolv.conf or any other
 # file, getting its servers from this file instead (see below), then
 # uncomment this.
-#dnsmasq_configure_no_resolv: True
+#dnsmasq_configure_no_resolv: true
 # If you don't want dnsmasq to poll /etc/resolv.conf or other resolv
 # files for changes and re-read them then uncomment this.
-#dnsmasq_configure_no_poll: True
+#dnsmasq_configure_no_poll: true
 
 # Add other name servers here, with domain specs if they are for
 # non-public domains.
@@ -163,11 +163,11 @@ dnsmasq_configure_disable_systemd_resolved: False
 # want dnsmasq to really bind only the interfaces it is listening on,
 # uncomment this option. About the only time you may need this is when
 # running another nameserver on the same machine.
-#dnsmasq_configure_bind_interfaces: True
+#dnsmasq_configure_bind_interfaces: true
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.
-#dnsmasq_configure_no_hosts: True
+#dnsmasq_configure_no_hosts: true
 # or if you want it to read another file, as well as /etc/hosts, use
 # this.
 #dnsmasq_configure_addn_hosts:
@@ -175,7 +175,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 
 # Set this (and domain: see below) if you want to have a domain
 # automatically added to simple names in a hosts-file.
-#dnsmasq_configure_expand_hosts: True
+#dnsmasq_configure_expand_hosts: true
 
 # Set the domain for dnsmasq. this is optional, but if it is set, it
 # does the following things.
@@ -257,7 +257,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 # Do Router Advertisements, BUT NOT DHCP for this subnet.
 #dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
-#    ra_only: True
+#    ra_only: true
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet, also try and
 # add names to the DNS for the IPv6 address of SLAAC-configured dual-stack 
@@ -266,13 +266,13 @@ dnsmasq_configure_disable_systemd_resolved: False
 # IPv6 address calculated using the SLAAC alogrithm.
 #dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
-#    ra_names: True
+#    ra_names: true
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet.
 # Set the lifetime to 46 hours. (Note: minimum lifetime is 2 hours.)
 #dnsmasq_configure_dhcp_ranges:
 #  - subnet:  '1234::'
-#    ra_only: True
+#    ra_only: true
 #    duration: '48h'
 
 # Do DHCP and Router Advertisements for this subnet. Set the A bit in the RA
@@ -281,29 +281,29 @@ dnsmasq_configure_disable_systemd_resolved: False
 #  - range:
 #      from: '1234::2'
 #      to: '1234::500'
-#    slaac: True
+#    slaac: true
 
 # Do Router Advertisements and stateless DHCP for this subnet. Clients will
 # not get addresses from DHCP, but they will get other configuration information.
 # They will use SLAAC for addresses.
 #dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
-#    ra_stateless: True
+#    ra_stateless: true
 
 # Do stateless DHCP, SLAAC, and generate DNS names for SLAAC addresses
 # from DHCPv4 leases.
 #dhcp-range=1234::, ra-stateless, ra-names
 #dnsmasq_configure_dhcp_ranges:
 #  - subnet: '1234::'
-#    ra_stateless: True
-#    ra_names: True
+#    ra_stateless: true
+#    ra_names: true
 
 # Do router advertisements for all subnets where we're doing DHCPv6
 # Unless overriden by ra-stateless, ra-names, et al, the router 
 # advertisements will have the M and O bits set, so that the clients
 # get addresses and configuration from DHCPv6, and the A bit reset, so the 
 # clients don't use SLAAC addresses.
-#dnsmasq_configure_enable_ra: True
+#dnsmasq_configure_enable_ra: true
 
 # Supply parameters for specified hosts using DHCP. There are lots
 # of valid alternatives, so we will give examples of each. Note that
@@ -337,7 +337,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 #dnsmasq_configure_dhcp_hosts:
 #  - mac: bert
 #    address: '192.168.0.70'
-#    infinite: True
+#    infinite: true
 
 # Always give the host with client identifier 01:02:02:04
 # the IP address 192.168.0.60
@@ -370,7 +370,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 # address is 11:22:33:44:55:66
 #dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
-#    ignore: True
+#    ignore: true
 
 # Ignore any client-id presented by the machine with Ethernet
 # address 11:22:33:44:55:66. This is useful to prevent a machine
@@ -378,7 +378,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 # between PXE boot and OS boot.
 #dnsmasq_configure_dhcp_hosts:
 #  - mac: '11:22:33:44:55:66'
-#    ignore_all: True
+#    ignore_all: true
 
 # Send extra options which are tagged as "red" to
 # the machine with Ethernet address 11:22:33:44:55:66
@@ -429,7 +429,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 # on the ethernet-address/IP pairs found there just as if they had
 # been given as --dhcp-host options. Useful if you keep
 # MAC-address/host mappings there for other purposes.
-#dnsmasq_configure_read_ethers: True
+#dnsmasq_configure_read_ethers: true
 
 # Send options to hosts which ask for a DHCP lease.
 # See RFC 2132 for details of available options.
@@ -612,25 +612,25 @@ dnsmasq_configure_disable_systemd_resolved: False
 # See http://syslinux.zytor.com/pxe.php#special for details.
 # Magic number - needed before anything else is recognised
 #dnsmasq_configure_dhcp_options:
-#  - force: True
+#  - force: true
 #    opt: 208
 #    val: f1:00:74:7e
 
 # Configuration file name
 #dnsmasq_configure_dhcp_options:
-#  - force: True
+#  - force: true
 #    opt: 209
 #    val: configs/common
 
 # Path prefix
 #dnsmasq_configure_dhcp_options:
-#  - force: True
+#  - force: true
 #    opt: 10
 #    val: /tftpboot/pxelinux/files/
 
 # Reboot time. (Note 'i' to send 32-bit value)
 #dnsmasq_configure_dhcp_options:
-#  - force: True
+#  - force: true
 #    opt: 211
 #    val: '30i'
 
@@ -747,22 +747,22 @@ dnsmasq_configure_disable_systemd_resolved: False
 #    tftp_server: 1.2.3.4
 
 # Enable dnsmasq's built-in TFTP server
-#dnsmasq_configure_enable_tftp: True
+#dnsmasq_configure_enable_tftp: true
 
 # Set the root directory for files available via FTP.
 #dnsmasq_configure_tftp_root: /var/lib/tftpboot
 
 # Do not abort if the tftp-root is unavailable
-#dnsmasq_configure_tftp_no_fail: True
+#dnsmasq_configure_tftp_no_fail: true
 
 # Make the TFTP server more secure: with this set, only files owned by
 # the user dnsmasq is running as will be send over the net.
-#dnsmasq_configure_tftp_secure: True
+#dnsmasq_configure_tftp_secure: true
 
 # This option stops dnsmasq from negotiating a larger blocksize for TFTP
 # transfers. It will slow things down, but may rescue some broken TFTP
 # clients.
-#dnsmasq_configure_tftp_no_blocksize: True
+#dnsmasq_configure_tftp_no_blocksize: true
 
 # Set the boot file name only when the "red" tag is set.
 #dnsmasq_configure_dhcp_boots:
@@ -806,7 +806,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 # server for your campus/company accidentally. The ISC server uses
 # the same option, and this URL provides more information:
 # http://www.isc.org/files/auth.html
-#dnsmasq_configure_dhcp_authoritative: True
+#dnsmasq_configure_dhcp_authoritative: true
 
 # Run an executable when a DHCP lease is created or destroyed.
 # The arguments sent to the script are "add" or "del",
@@ -818,7 +818,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 #dnsmasq_configure_cache_size: 150
 
 # If you want to disable negative caching, uncomment this.
-#dnsmasq_configure_no_negcache: True
+#dnsmasq_configure_no_negcache: true
 
 # Normally responses which come from /etc/hosts and the DHCP lease
 # file have Time-To-Live set as zero, which conventionally means
@@ -867,10 +867,10 @@ dnsmasq_configure_disable_systemd_resolved: False
 
 # Return an MX record pointing to the mx-target for all local
 # machines.
-#dnsmasq_configure_localmx: True
+#dnsmasq_configure_localmx: true
 
 # Return an MX record pointing to itself for all local machines.
-#dnsmasq_configure_selfmx: True
+#dnsmasq_configure_selfmx: true
 
 # Change the following lines if you want dnsmasq to serve SRV
 # records.  These are useful if you want to serve ldap requests for
@@ -949,10 +949,10 @@ dnsmasq_configure_disable_systemd_resolved: False
 
 # For debugging purposes, log each DNS query as it passes through
 # dnsmasq.
-#dnsmasq_configure_log_queries: True
+#dnsmasq_configure_log_queries: true
 
 # Log lots of extra information about DHCP transactions.
-#dnsmasq_configure_log_dhcp: True
+#dnsmasq_configure_log_dhcp: true
 
 # Include another lot of configuration options.
 #dnsmasq_configure_conf_files:
@@ -980,4 +980,4 @@ dnsmasq_configure_disable_systemd_resolved: False
 #      - .rpmsave
 #      - .rpmorig
 
-#dnsmasq_configure_dhcp_log: True
+#dnsmasq_configure_dhcp_log: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,7 +64,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 #dnsmasq_configure_no_resolv: True
 # If you don't want dnsmasq to poll /etc/resolv.conf or other resolv
 # files for changes and re-read them then uncomment this.
-#dnsmasq_configure_no-poll
+#dnsmasq_configure_no_poll: True
 
 # Add other name servers here, with domain specs if they are for
 # non-public domains.
@@ -96,12 +96,14 @@ dnsmasq_configure_disable_systemd_resolved: False
 # Add domains which you want to force to an IP address here.
 # The example below send any host in double-click.net to a local
 # web-server.
-#dnsmasq_configure_address:
-#  double-click.net: '127.0.0.1'
+#dnsmasq_configure_addresses:
+#  - domain: double-click.net
+#    ip: '127.0.0.1'
 
 # --address (and --server) work with IPv6 addresses too.
-#dnsmasq_configure_address:
-#  www.thekelleys.org.uk: 'fe80::20d:60ff:fe36:f83'
+#dnsmasq_configure_addresses:
+#  - domain: www.thekelleys.org.uk
+#    ip: 'fe80::20d:60ff:fe36:f83'
 
 # Add the IPs of all queries to yahoo.com, google.com, and their
 # subdomains to the vpn and search ipsets:
@@ -245,7 +247,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 
 # Enable DHCPv6. Note that the prefix-length does not need to be specified
 # and defaults to 64 if missing/
-#dnamsq_configure_dhcp_ranges:
+#dnsmasq_configure_dhcp_ranges:
 #  - range:
 #      from: '1234::2'
 #      to: '1234::500'
@@ -407,13 +409,13 @@ dnsmasq_configure_disable_systemd_resolved: False
 
 # Send extra options which are tagged as "red" to any machine whose
 # DHCP vendorclass string includes the substring "Linux"
-#dnsmasq_configure_dhcp_vendorclasses:
+#dnsmasq_configure_dhcp_vendor_classes:
 #  - set: red
 #    includes: Linux
 
 # Send extra options which are tagged as "red" to any machine one
 # of whose DHCP userclass strings includes the substring "accounts"
-#dnsmasq_configure_dhcp_userclasses:
+#dnsmasq_configure_dhcp_user_classes:
 #  - set: red
 #    includes: accounts
 
@@ -837,7 +839,7 @@ dnsmasq_configure_disable_systemd_resolved: False
 # This alias makes a result of 1.2.3.4 appear as 5.6.7.8
 #dnsmasq_configure_aliases:
 #  - src: '1.2.3.4'
-#    target: '5.6.7.8'
+#    dest: '5.6.7.8'
 
 # and this maps 1.2.3.x to 5.6.7.x
 #dnsmasq_configure_aliases:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -867,10 +867,10 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # Return an MX record pointing to the mx-target for all local
 # machines.
-#dnsmasq_configure_localmx: true
+# dnsmasq_configure_localmx: true
 
 # Return an MX record pointing to itself for all local machines.
-#dnsmasq_configure_selfmx: true
+# dnsmasq_configure_selfmx: true
 
 # Change the following lines if you want dnsmasq to serve SRV
 # records.  These are useful if you want to serve ldap requests for
@@ -885,22 +885,22 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # A SRV record sending LDAP for the example.com domain to
 # ldapserver.example.com port 389
-#dnsmasq_configure_srv_hosts:
-#  - name: _ldap._tcp.example.com
+# dnsmasq_configure_srv_hosts:
+#   - name: _ldap._tcp.example.com
 #    target: ldapserver.example.com
 #    port: 389
 
 # A SRV record sending LDAP for the example.com domain to
 # ldapserver.example.com port 389 (using domain=)
-#dnsmasq_configure_srv_hosts:
-#  - domain: example.com
+# dnsmasq_configure_srv_hosts:
+#   - domain: example.com
 #    name: _ldap._tcp
 #    target: ldapserver.example.com
 #    port: 389
 
 # Two SRV records for LDAP, each with different priorities
-#dnsmasq_configure_srv_hosts:
-#  - name: _ldap._tcp.example.com
+# dnsmasq_configure_srv_hosts:
+#   - name: _ldap._tcp.example.com
 #    target: ldapserver.example.com
 #    port: 389
 #    priority: 1
@@ -911,15 +911,15 @@ dnsmasq_configure_disable_systemd_resolved: false
 
 # A SRV record indicating that there is no LDAP server for the domain
 # example.com
-#dnsmasq_configure_srv_hosts:
-#  - name: _ldap._tcp.example.com
+# dnsmasq_configure_srv_hosts:
+#   - name: _ldap._tcp.example.com
 
 # The following line shows how to make dnsmasq serve an arbitrary PTR
 # record. This is useful for DNS-SD. (Note that the
 # domain-name expansion done for SRV records _does_not
 # occur for PTR records.)
-#dnsmasq_configure_ptr_records:
-#  - name: _http._tcp.dns-sd-services
+# dnsmasq_configure_ptr_records:
+#   - name: _http._tcp.dns-sd-services
 #    val: New Employee Page._http._tcp.dns-sd-services
 
 # Change the following lines to enable dnsmasq to serve TXT records.
@@ -927,15 +927,15 @@ dnsmasq_configure_disable_systemd_resolved: false
 # domain-name expansion done for SRV records _does_not
 # occur for TXT records.)
 
-#Example SPF.
-#dnsmasq_configure_txt_records:
-#  - name: example.com
+# Example SPF.
+# dnsmasq_configure_txt_records:
+#   - name: example.com
 #    vals:
 #      - v=spf1 a -all
 
-#Example zeroconf
-#dnsmasq_configure_txt_records:
-#  - name: _http._tcp.example.com
+# Example zeroconf
+# dnsmasq_configure_txt_records:
+#   - name: _http._tcp.example.com
 #    vals:
 #      - name=value
 #      - paper=A4
@@ -943,41 +943,41 @@ dnsmasq_configure_disable_systemd_resolved: false
 # Provide an alias for a "local" DNS name. Note that this _only_ works
 # for targets which are names from DHCP or /etc/hosts. Give host
 # "bert" another name, bertrand
-#dnsmasq_configure_cnames:
-#  - local: bertand
+# dnsmasq_configure_cnames:
+#   - local: bertand
 #    alias: bert
 
 # For debugging purposes, log each DNS query as it passes through
 # dnsmasq.
-#dnsmasq_configure_log_queries: true
+# dnsmasq_configure_log_queries: true
 
 # Log lots of extra information about DHCP transactions.
-#dnsmasq_configure_log_dhcp: true
+# dnsmasq_configure_log_dhcp: true
 
 # Include another lot of configuration options.
-#dnsmasq_configure_conf_files:
-#  - /etc/dnsmasq.more.conf
-#dnsmasq_configure_conf_dirs:
-#  - d: /etc/dnsmasq.d
+# dnsmasq_configure_conf_files:
+#   - /etc/dnsmasq.more.conf
+# dnsmasq_configure_conf_dirs:
+#   - d: /etc/dnsmasq.d
 
 # Include all the files in a directory except those ending in .bak
-#dnsmasq_configure_conf_dirs:
-#  - d: /etc/dnsmasq.d
-#    excepts:
+# dnsmasq_configure_conf_dirs:
+#   - d: /etc/dnsmasq.d
+#     excepts:
 #      - .bak
 
 # Include all files in a directory which end in .conf
-#dnsmasq_configure_conf_dirs:
-#  - d: /etc/dnsmasq.d/
-#    includes:
+# dnsmasq_configure_conf_dirs:
+#   - d: /etc/dnsmasq.d/
+#     includes:
 #      - .conf
 
 # Include all files in /etc/dnsmasq.d except RPM backup files
-#dnsmasq_configure_conf_dirs:
-#  - d: /etc/dnsmasq.d
-#    excepts:
+# dnsmasq_configure_conf_dirs:
+#   - d: /etc/dnsmasq.d
+#     excepts:
 #      - .rpmnew
 #      - .rpmsave
 #      - .rpmorig
 
-#dnsmasq_configure_dhcp_log: true
+# dnsmasq_configure_dhcp_log: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # handlers file for dnsmasq-configure
-- name: dnsmasq_configure_restart
+- name: Dnsmasq_configure_restart
   become: '{{ dnsmasq_configure_privilege_escalate }}'
   become_user: root
   when: dnsmasq_configure_activate

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,6 @@
   become: '{{ dnsmasq_configure_privilege_escalate }}'
   become_user: root
   when: dnsmasq_configure_activate
-  service:
+  ansible.builtin.service:
     name: dnsmasq
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,17 +18,19 @@ galaxy_info:
     - name: Debian
       versions:
         - bookworm
-        - bullseye
+        - trixie
     - name: EL
       versions:
-        - '8'
+        - '10'
         - '9'
     - name: Fedora
       versions:
-        - '38'
-        - '39'
+        - all
+    - name: Kali
+      versions:
+        - all
     - name: Ubuntu
       versions:
-        - focal
         - jammy
+        - noble
   role_name: dnsmasq_configure

--- a/platform-matrix-v1.json
+++ b/platform-matrix-v1.json
@@ -1,50 +1,77 @@
 [
   {
     "OS": "alpine",
-    "OS_VER": "3.18"
+    "OS_VER": "3.22",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "alpine",
-    "OS_VER": "3.19"
+    "OS_VER": "3.23",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "alpine",
-    "OS_VER": "edge"
+    "OS_VER": "edge",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "archlinux",
-    "OS_VER": "latest"
+    "OS_VER": "latest",
+    "platforms": "linux/amd64"
   },
   {
     "OS": "debian",
-    "OS_VER": "bookworm"
+    "OS_VER": "bookworm",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "debian",
-    "OS_VER": "bullseye"
+    "OS_VER": "trixie",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "fedora",
-    "OS_VER": "38"
+    "OS_VER": "43",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "fedora",
-    "OS_VER": "39"
+    "OS_VER": "44",
+    "platforms": "linux/amd64,linux/arm64"
+  },
+  {
+    "OS": "kali",
+    "OS_VER": "latest",
+    "platforms": "linux/amd64"
   },
   {
     "OS": "rockylinux",
-    "OS_VER": "8"
+    "OS_VER": "9",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "rockylinux",
-    "OS_VER": "9"
+    "OS_VER": "10",
+    "platforms": "linux/amd64,linux/arm64"
+  },
+  {
+    "OS": "ubi",
+    "OS_VER": "9",
+    "platforms": "linux/amd64,linux/arm64"
+  },
+  {
+    "OS": "ubi",
+    "OS_VER": "10",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "ubuntu",
-    "OS_VER": "focal"
+    "OS_VER": "jammy",
+    "platforms": "linux/amd64,linux/arm64"
   },
   {
     "OS": "ubuntu",
-    "OS_VER": "jammy"
+    "OS_VER": "noble",
+    "platforms": "linux/amd64,linux/arm64"
   }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-ansible-galaxy-local-deps == 0.1.0
-dcb == 0.1.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Templatizing {{ dnsmasq_configure_conf_path }}
   become: '{{ dnsmasq_configure_privilege_escalate }}'
   become_user: root
-  notify: dnsmasq_configure_restart
+  notify: Dnsmasq_configure_restart
   ansible.builtin.template:
     src: dnsmasq.conf.j2
     dest: '{{ dnsmasq_configure_conf_path }}'

--- a/templates/dnsmasq.conf.j2
+++ b/templates/dnsmasq.conf.j2
@@ -51,14 +51,14 @@ server=
 {% endfor %}
 
 {%- for rs in dnsmasq_configure_rev_servers | default([]) %}
-{%   if rs.subnet is defined %}
+{%-  if rs.subnet is defined %}
 rev-server={{ rs.subnet }},{{ rs.nameserver }}
-{%   elif rs.subnets is defined %}
-{%     for s in rs.subnets %}
+{%-  elif rs.subnets is defined %}
+{%-    for s in rs.subnets %}
 rev-server={{ s }},{{ rs.nameserver }}
-{%     endfor %}
-{%   endif %}
-{% endfor %}
+{%-    endfor %}
+{%-  endif %}
+{%- endfor %}
 
 {%- for d in dnsmasq_configure_locals | default([]) %}
 local=/{{ d }}/
@@ -193,11 +193,11 @@ dhcp-option{% if o.force | default(False) | bool %}-force{% endif %}=
 {%- for b in dnsmasq_configure_dhcp_boots | default([]) %}
 dhcp-boot=
 {%-  if b.tag is defined %}tag:{{ b.tag }}
-{%-  elif b.tags is defined -%}tag:{{ b.tags | join(",tag:") }}
+{%-  elif b.tags is defined %}tag:{{ b.tags | join(",tag:") }}
 {%-  endif %},{{ b.file }}
-{%-  if b.tftp_servername is defined %},{{ b.tftp_servername }}{%  endif %}
-{%-  if b.tftp_servernames is defined %},{{ b.tftp_servernames | join(",") }}{%  endif +%}
-{% endfor %}
+{%-  if b.tftp_servername is defined %},{{ b.tftp_servername }}{% endif %}
+{%-  if b.tftp_servernames is defined %},{{ b.tftp_servernames | join(",") }}{% endif +%}
+{%- endfor %}
 
 {%- for m in dnsmasq_configure_dhcp_matches | default([]) %}
 dhcp-match=
@@ -294,9 +294,9 @@ selfmx
 {% endif %}
 
 {%- for h in dnsmasq_configure_srv_hosts | default([]) %}
-{%   if h.domain is defined %}
+{%-  if h.domain is defined %}
 domain={{ h.domain }}
-{%   endif %}
+{%-  endif %}
 srv-host={{ h.name }}
 {%-  if h.target is defined %},{{ h.target }}{% endif %}
 {%-  if h.port is defined %},{{ h.port }}{% endif %}

--- a/templates/dnsmasq.conf.j2
+++ b/templates/dnsmasq.conf.j2
@@ -1,5 +1,5 @@
 # dnsmasq.conf
-{% if dnsmasq_configure_port is defined %}
+{%- if dnsmasq_configure_port is defined %}
 port={{ dnsmasq_configure_port }}
 {% endif %}
 
@@ -73,10 +73,10 @@ ipset={{ s.domains | join('/') }}/{{ s.sets | join(',') }}
 {% endfor %}
 
 {%- for s in dnsmasq_configure_nftsets | default([]) %}
-ntfset={{ s.domains | join('/') }}/{{ s.sets | join(',') }}
+nftset={{ s.domains | join('/') }}/{{ s.sets | join(',') }}
 {% endfor %}
 
-{%- for s in dnsmasq_configure_talks %}
+{%- for s in dnsmasq_configure_talks | default([]) %}
 server={{ s.server }}@{{ s.target }}
 {%-  if s.port is defined %}#{{ s.port }}{% endif +%}
 {% endfor %}
@@ -186,7 +186,7 @@ read-ethers
 dhcp-option{% if o.force | default(False) | bool %}-force{% endif %}=
 {%-  if o.tag is defined %}{{ o.tag }},{% endif %}{{ o.opt }}
 {%-  if o.val is defined %},{{ o.val }}
-{%-  elif o.vals is defined %}{{ o.vals | join(",") }}
+{%-  elif o.vals is defined %},{{ o.vals | join(",") }}
 {%-  endif +%}
 {% endfor %}
 
@@ -271,7 +271,7 @@ bogus-nxdomain={{ dnsmasq_configure_bogus_nxdomain }}
 {% endif %}
 
 {%- for a in dnsmasq_configure_aliases | default([]) %}
-alias={{ a.src }},{{ a.target }}
+alias={{ a.src }},{{ a.dest }}
   {%- if a.netmask is defined %},{{ a.netmask }}{% endif +%}
 {% endfor %}
 
@@ -332,5 +332,5 @@ conf-file={{ f }}
 {%- for d in dnsmasq_configure_conf_dirs | default([]) %}
 conf-dir={{ d.d }}
   {%- if d.includes is defined %},*{{ d.includes | join(",*") }}{% endif %}
-  {%- if d.excludes is defined %},{{ d.excludes | join(",") }}{% endif +%}
+  {%- if d.excepts is defined %},{{ d.excepts | join(",") }}{% endif +%}
 {% endfor %}

--- a/test.yml
+++ b/test.yml
@@ -197,9 +197,9 @@
     dnsmasq_configure_bogus_nxdomain: 64.94.110.11
     dnsmasq_configure_aliases:
       - src: 1.2.3.4
-        target: 5.6.7.8
+        dest: 5.6.7.8
       - src: 1.2.3.0
-        target: 5.6.7.0
+        dest: 5.6.7.0
         netmask: 255.255.255.0
     dnsmasq_configure_mx_host:
       record: maildomain.com
@@ -246,7 +246,7 @@
         includes:
           - .conf
       - d: /etc/dnsmasq.d
-        excludes:
+        excepts:
           - .bak
   roles:
     - role: '{{ playbook_dir }}'


### PR DESCRIPTION
## Summary
- Fix `nftset` typo (was `ntfset`) in template
- Add missing `| default([])` to `dnsmasq_configure_talks` preventing undefined variable errors
- Add missing comma in `dhcp_options` vals output
- Fix variable naming inconsistencies between defaults and template (`vendor_classes`, `user_classes`, `excepts`, `dest`, `addresses`)
- Fix typos in defaults (`dnamsq`, `no-poll`)
- Use FQCN `ansible.builtin.service` in handlers

## Test plan
- [ ] Run role with various dnsmasq configuration options
- [ ] Verify generated `dnsmasq.conf` output is valid
- [ ] Test with `dnsmasq --test` to validate config syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)